### PR TITLE
Do not at_exit to close the streams

### DIFF
--- a/lib/escort.rb
+++ b/lib/escort.rb
@@ -69,10 +69,6 @@ module Escort
   end
 end
 
-at_exit do
-  Escort::Logger.close
-end
-
 def error_logger
   Escort::Logger.error
 end
@@ -80,5 +76,3 @@ end
 def output_logger
   Escort::Logger.output
 end
-
-


### PR DESCRIPTION
This resolves a conflict in any code that loads both Escort and Minitest (i.e., our tests sometimes (-:). I am pretty sure it's safe to not close the logger at exit anyway - IOs get flushed automatically, so I believe this change preserves current semantics safely, while increasing compatibility with other gems.