### PR TITLE
support negative value for the option with int type

### DIFF
--- a/lib/escort/trollop.rb
+++ b/lib/escort/trollop.rb
@@ -607,7 +607,7 @@ private
   end
 
   def parse_integer_parameter param, arg
-    raise CommandlineError, "option '#{arg}' needs an integer" unless param =~ /^\d+$/
+    raise CommandlineError, "option '#{arg}' needs an integer" unless param =~ /^[+-]?\d+$/
     param.to_i
   end
 


### PR DESCRIPTION
The int (or ints) type option should sometimes be negative